### PR TITLE
 Jpostcode::Address.zip_code is not set

### DIFF
--- a/lib/jpostcode/address.rb
+++ b/lib/jpostcode/address.rb
@@ -6,7 +6,7 @@ module Jpostcode
                 :city, :city_kana, :town, :town_kana, :street,
                 :office_name, :office_name_kana
 
-    alias_method :postcode, :zip_code
+    alias postcode zip_code
 
     def initialize(data)
       @zip_code         = data['postcode']

--- a/lib/jpostcode/address.rb
+++ b/lib/jpostcode/address.rb
@@ -6,8 +6,10 @@ module Jpostcode
                 :city, :city_kana, :town, :town_kana, :street,
                 :office_name, :office_name_kana
 
+    alias_method :postcode, :zip_code
+
     def initialize(data)
-      @zip_code         = data['zip_code']
+      @zip_code         = data['postcode']
       @prefecture       = data['prefecture']
       @prefecture_kana  = data['prefecture_kana']
       @prefecture_code  = data['prefecture_code']

--- a/spec/jpostcode_spec.rb
+++ b/spec/jpostcode_spec.rb
@@ -64,7 +64,7 @@ describe Jpostcode do
       end
     end
 
-    context 'when specified postcode DOES NTO exist' do
+    context 'when specified postcode DOES NOT exist' do
       context 'when the code is nil' do
         let(:postcode) { nil }
         it { expect(result).to be_nil }

--- a/spec/jpostcode_spec.rb
+++ b/spec/jpostcode_spec.rb
@@ -10,6 +10,7 @@ describe Jpostcode do
       context 'when there is only one address for the code' do
         let(:postcode) { '154-0011' }
         it 'returns a single record' do
+          expect(result.zip_code).to eq('1540011')
           expect(result.prefecture).to eq('東京都')
           expect(result.prefecture_kana).to eq('トウキョウト')
           expect(result.prefecture_code).to eq(13)
@@ -25,6 +26,7 @@ describe Jpostcode do
         it 'returns array of addresses for the code' do
           expect(result.class).to eq(Array)
 
+          expect(result[0].zip_code).to eq('0110951')
           expect(result[0].prefecture).to eq('秋田県')
           expect(result[0].prefecture_kana).to eq('アキタケン')
           expect(result[0].city).to eq('秋田市')
@@ -33,6 +35,7 @@ describe Jpostcode do
           expect(result[0].town_kana).to eq('ツチザキミナトソウゼンマチ')
           expect(result[0].prefecture_code).to eq(5)
 
+          expect(result[1].zip_code).to eq('0110951')
           expect(result[1].prefecture).to eq('秋田県')
           expect(result[1].prefecture_kana).to eq('アキタケン')
           expect(result[1].city).to eq('秋田市')
@@ -46,6 +49,7 @@ describe Jpostcode do
       context 'when the code is an office postcode' do
         let(:postcode) { '113-8654' }
         it 'returns an office address' do
+          expect(result.zip_code).to eq('1138654')
           expect(result.prefecture).to eq('東京都')
           expect(result.prefecture_kana).to eq('トウキョウト')
           expect(result.prefecture_code).to eq(13)


### PR DESCRIPTION
I am using latest version of jpostcode-rb in my product.
I noticed that I could not get Address.zip_code so I fixed it.

```
[126] pry(main)> a = Jpostcode.find("1500022")
=> #<Jpostcode::Address:0x00007fe3d04f4c80 @city="渋谷区", @city_kana="シブヤク", @office_name=nil, @office_name_kana=nil, @prefecture="東京都", @prefecture_code=13, @prefecture_kana="トウキョウト", @street=nil, @town="恵比寿南", @town_kana="エビスミナミ", @zip_code=nil>

[127] pry(main)> a.zip_code
=> nil
```
