### PR TITLE
Fix jpostcode-data directory was not included in gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,10 @@ jobs:
       GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
       GEM_HOST_OTP_CODE: ${{ github.event.inputs.rubygems-otp-code }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
-          fetch-depth: 0
+        fetch-depth: 0
+        submodules: true
 
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Fixed `jpostcode-data` directory was not included in the gem from `jpostcode-1.0.0.20240701`.

```
/path/to/ruby/3.2.4/lib/ruby/gems/3.2.0/gems/jpostcode-1.0.0.20240601/:
bin
CHANGELOG.md
CODE_OF_CONDUCT.md
Gemfile
Gemfile.lock
Guardfile
jpostcode-data
jpostcode.gemspec
lib
LICENSE.txt
Rakefile
README.md

/path/to/ruby/3.2.4/lib/ruby/gems/3.2.0/gems/jpostcode-1.0.0.20240701/:
bin
CHANGELOG.md
CODE_OF_CONDUCT.md
Gemfile
Gemfile.lock
Guardfile
jpostcode.gemspec
lib
LICENSE.txt
Rakefile
README.md
```

The gem release was changed to GitHub Actions, but the submodule was not checked out. #553
I added submodules settings and updated actions.
see: https://github.com/actions/checkout